### PR TITLE
remove eve horizontal and stacked images

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In this repo, we provide artwork in standard formats for the LF Edge [projects](
 
 <img src="/homeedge/horizontal/color/homeedge-horizontal-color.png"  width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="/homeedge/stacked/color/homeedge-stacked-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="/homeedge/icon/color/homeedge-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
 
-<img src="/project-eve/horizontal/color/eve-horizontal-color.png"  width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="/project-eve/stacked/color/eve-stacked-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="/project-eve/icon/color/eve-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+<img src="/project-eve/icon/color/eve-icon-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">
 
 <img src="/baetyl/horizontal/color/baetyl_horizontal-color.png"  width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="/baetyl/icon/color/baetyl_icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
 


### PR DESCRIPTION
EVE has dropped the text Edge Virtualization Engine around their logos.  Thus the horizontal and stacked images were removed from the github repo.  This requires that in this md file, we remove the calls to those images.